### PR TITLE
Add Podman-based CI and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman shellcheck bats python3-pip
+          pip3 install flake8
+      - name: ShellCheck
+        run: shellcheck $(git ls-files "*.sh")
+      - name: Flake8
+        run: flake8 scripts/notifications/kde-notify-dbus.py
+      - name: Run Bats tests
+        run: bats tests
+      - name: Build integration container
+        run: podman build -t backup-test -f Containerfile .
+      - name: Run integration test
+        run: podman run --rm backup-test
+

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,12 @@
+FROM archlinux:latest
+
+RUN pacman -Sy --noconfirm btrfs-progs btrbk restic python sudo
+
+RUN useradd -m tester && echo "tester ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/tester
+
+USER tester
+WORKDIR /home/tester/app
+COPY . /home/tester/app
+
+ENTRYPOINT ["/home/tester/app/scripts/test-installation.sh"]
+

--- a/README.md
+++ b/README.md
@@ -159,6 +159,25 @@ Contributions are welcome! Please:
 4. Add tests if applicable
 5. Submit a pull request
 
+## Testing & Continuous Integration
+
+Automated tests run via GitHub Actions. The workflow uses **Podman** to build an Arch Linux container and execute `scripts/test-installation.sh`.
+Static analysis with ShellCheck and Flake8 as well as Bats unit tests are run on each pull request.
+
+To run the checks locally:
+
+```bash
+# install dependencies using your package manager
+# example on Arch Linux
+sudo pacman -S podman shellcheck bats-core python-flake8
+
+# run tests
+bats tests
+podman build -t backup-test -f Containerfile .
+podman run --rm backup-test
+```
+
+
 ## Requirements
 
 - Arch Linux

--- a/tests/test_load_config.bats
+++ b/tests/test_load_config.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+@test "load-config sets dev mode paths" {
+  run bash -c 'source scripts/common/load-config.sh && echo "$BACKUP_DEV_MODE $BTRBK_CONFIG"'
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == true* ]]
+  [[ "${lines[0]}" == *"configs/btrbk.conf" ]]
+}
+


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow using Podman
- provide integration Containerfile
- write a small Bats unit test for load-config
- document how to run the new Podman-based tests

## Testing
- `apt-get update` *(fails: repository not signed)*
- `shellcheck --version` *(fails: command not found)*
- `bats --version` *(fails: command not found)*
- `flake8 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68850ba6f54c8329b855189df0badcd4