### PR TITLE
Fix ShellCheck warnings

### DIFF
--- a/scripts/backup/master-backup.sh
+++ b/scripts/backup/master-backup.sh
@@ -7,6 +7,7 @@ set -e
 
 # Load common configuration
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+# shellcheck source=../common/load-config.sh
 source "${SCRIPT_DIR}/../common/load-config.sh"
 
 # Use the notify function from common config
@@ -68,7 +69,7 @@ echo "Backup Summary"
 echo "========================================"
 
 echo "Current backups on target drive:"
-ls -lah "$BTRBK_SNAPSHOTS_DIR" | grep -E "(ROOT|home-essential)" | tail -10
+ls -lah "$BTRBK_SNAPSHOTS_DIR"/ROOT* "$BTRBK_SNAPSHOTS_DIR"/home-essential* 2>/dev/null | tail -10
 
 echo ""
 echo "Disk usage after backup:"

--- a/scripts/backup/selective-home-backup.sh
+++ b/scripts/backup/selective-home-backup.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 # Load common configuration
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+# shellcheck source=../common/load-config.sh
 source "${SCRIPT_DIR}/../common/load-config.sh"
 
 TIMESTAMP=$(date +%Y%m%dT%H%M)

--- a/scripts/backup/system-backup.sh
+++ b/scripts/backup/system-backup.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 # Load common configuration
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+# shellcheck source=../common/load-config.sh
 source "${SCRIPT_DIR}/../common/load-config.sh"
 
 # Trap to handle errors and send failure notification
@@ -23,6 +24,7 @@ if command -v systemd-creds &> /dev/null && systemd-creds list 2>/dev/null | gre
     export RESTIC_PASSWORD=$(systemd-creds cat restic-password)
 elif [[ -f "$RESTIC_ENV_FILE" ]]; then
     # Load from environment file
+    # shellcheck source=/dev/null
     source "$RESTIC_ENV_FILE"
 else
     echo "Error: No Restic environment configuration found!"
@@ -72,8 +74,8 @@ log "Backing up bootloader and partition table..."
 mkdir -p "$SYSTEM_BACKUPS_DIR/bootloader"
 sudo dd if=/dev/nvme0n1 of="$SYSTEM_BACKUPS_DIR/bootloader/nvme0n1-mbr-$BACKUP_DATE.img" bs=512 count=2048
 sudo dd if=/dev/nvme0n1p1 of="$SYSTEM_BACKUPS_DIR/bootloader/efi-partition-$BACKUP_DATE.img" bs=1M
-sudo sfdisk -d /dev/nvme0n1 > "$SYSTEM_BACKUPS_DIR/bootloader/partition-table-$BACKUP_DATE.txt"
-sudo efibootmgr -v > "$SYSTEM_BACKUPS_DIR/bootloader/efi-boot-entries-$BACKUP_DATE.txt"
+sudo sfdisk -d /dev/nvme0n1 | sudo tee "$SYSTEM_BACKUPS_DIR/bootloader/partition-table-$BACKUP_DATE.txt" > /dev/null
+sudo efibootmgr -v | sudo tee "$SYSTEM_BACKUPS_DIR/bootloader/efi-boot-entries-$BACKUP_DATE.txt" > /dev/null
 
 # 5. Restic backup for important directories
 log "Running Restic backup..."

--- a/scripts/common/load-config.sh
+++ b/scripts/common/load-config.sh
@@ -19,6 +19,7 @@ fi
 
 # Load user configuration if it exists
 if [[ -f "$BACKUP_CONFIG_FILE" ]]; then
+    # shellcheck source=/dev/null
     source "$BACKUP_CONFIG_FILE"
 fi
 

--- a/scripts/setup/migrate-to-generic.sh
+++ b/scripts/setup/migrate-to-generic.sh
@@ -69,6 +69,7 @@ echo -e "\n${YELLOW}4. Testing configuration...${NC}"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 if [[ -f "${SCRIPT_DIR}/../common/load-config.sh" ]]; then
+    # shellcheck source=../common/load-config.sh
     source "${SCRIPT_DIR}/../common/load-config.sh"
     
     echo "Loaded configuration:"

--- a/scripts/setup/restic-env-systemd.sh
+++ b/scripts/setup/restic-env-systemd.sh
@@ -6,8 +6,10 @@ set -euo pipefail
 
 # Load configuration
 if [[ -f "/etc/backup-system/backup.conf" ]]; then
+    # shellcheck source=/etc/backup-system/backup.conf
     source "/etc/backup-system/backup.conf"
 elif [[ -f "$HOME/.config/backup-system/backup.conf" ]]; then
+    # shellcheck source=/dev/null
     source "$HOME/.config/backup-system/backup.conf"
 else
     echo "Error: No backup configuration found!" >&2
@@ -24,6 +26,7 @@ if command -v systemd-creds &> /dev/null && systemd-creds list 2>/dev/null | gre
 elif [[ -f "$HOME/.config/backup-system/.restic-env" ]]; then
     # Load from user config
     set +x  # Ensure passwords aren't printed
+    # shellcheck source=/dev/null
     source "$HOME/.config/backup-system/.restic-env"
     set -x
 else

--- a/scripts/setup/setup-backup-system-new.sh
+++ b/scripts/setup/setup-backup-system-new.sh
@@ -13,6 +13,7 @@ NC='\033[0m' # No Color
 # Load configuration if running from repo
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 if [[ -f "${SCRIPT_DIR}/../common/load-config.sh" ]]; then
+    # shellcheck source=../common/load-config.sh
     source "${SCRIPT_DIR}/../common/load-config.sh"
 else
     # Set defaults if config not available
@@ -177,7 +178,7 @@ echo -e "\n${YELLOW}7. Creating user configuration...${NC}"
 
 USER_CONFIG="$ACTUAL_HOME/.config/backup-system/backup.conf"
 if [[ ! -f "$USER_CONFIG" ]]; then
-    sudo -u "$ACTUAL_USER" cat > "$USER_CONFIG" << EOF
+    sudo -u "$ACTUAL_USER" tee "$USER_CONFIG" > /dev/null << EOF
 # Backup System Configuration for $ACTUAL_USER
 # Customize these settings for your system
 
@@ -213,7 +214,7 @@ if [[ -d "$BACKUP_STORAGE_ROOT/restic-repo" ]] && [[ ! -f "$BACKUP_STORAGE_ROOT/
     
     # Create restic environment file
     RESTIC_ENV="$ACTUAL_HOME/.config/backup-system/.restic-env"
-    sudo -u "$ACTUAL_USER" cat > "$RESTIC_ENV" << EOF
+    sudo -u "$ACTUAL_USER" tee "$RESTIC_ENV" > /dev/null << EOF
 # Restic environment configuration
 export RESTIC_REPOSITORY="$BACKUP_STORAGE_ROOT/restic-repo"
 # export RESTIC_PASSWORD="your-password-here"

--- a/scripts/setup/setup-backup-system.sh
+++ b/scripts/setup/setup-backup-system.sh
@@ -104,8 +104,8 @@ tar -czf /mnt/raid-storage/system-backups/configs/dotfiles-$BACKUP_DATE.tar.gz \
 log "Backing up bootloader and partition table..."
 sudo dd if=/dev/nvme0n1 of=/mnt/raid-storage/system-backups/bootloader/nvme0n1-mbr-$BACKUP_DATE.img bs=512 count=2048
 sudo dd if=/dev/nvme0n1p1 of=/mnt/raid-storage/system-backups/bootloader/efi-partition-$BACKUP_DATE.img bs=1M
-sudo sfdisk -d /dev/nvme0n1 > /mnt/raid-storage/system-backups/bootloader/partition-table-$BACKUP_DATE.txt
-sudo efibootmgr -v > /mnt/raid-storage/system-backups/bootloader/efi-boot-entries-$BACKUP_DATE.txt
+sudo sfdisk -d /dev/nvme0n1 | sudo tee /mnt/raid-storage/system-backups/bootloader/partition-table-$BACKUP_DATE.txt > /dev/null
+sudo efibootmgr -v | sudo tee /mnt/raid-storage/system-backups/bootloader/efi-boot-entries-$BACKUP_DATE.txt > /dev/null
 
 # 5. Restic backup for important directories
 log "Running Restic backup..."

--- a/scripts/test-installation.sh
+++ b/scripts/test-installation.sh
@@ -60,6 +60,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 if [[ -f "${SCRIPT_DIR}/common/load-config.sh" ]]; then
     echo "Running from repository (development mode)"
+    # shellcheck source=common/load-config.sh
     source "${SCRIPT_DIR}/common/load-config.sh"
 elif [[ -f "/usr/local/bin/backup-load-config.sh" ]]; then
     echo "Running from installed location"


### PR DESCRIPTION
## Summary
- silence non-constant `source` paths for ShellCheck
- replace `ls | grep` usage with globbing
- redirect privileged output with `sudo tee`

## Testing
- `bash scripts/test-installation.sh` *(fails: "Checking btrbk installation... FAILED")*

------
https://chatgpt.com/codex/tasks/task_e_6885137efa9c832986d8ced2e74d0992