### PR TITLE
Remove hardcoded username path from restore-helper

### DIFF
--- a/scripts/backup/restore-helper.sh
+++ b/scripts/backup/restore-helper.sh
@@ -43,7 +43,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
                 sudo btrbk -c "$HOME/scripts/btrbk.conf" list
                 ;;
             "List Restic snapshots")
-                # shellcheck source=/home/b3l13v3r/scripts/.restic-env
+                # shellcheck source=$HOME/scripts/.restic-env
                 source "$HOME/scripts/.restic-env"
                 restic snapshots
                 ;;


### PR DESCRIPTION
## Summary
- remove leftover reference to /home/b3l13v3r in restore helper

## Testing
- `npx bats tests` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68851cdb40508329b405507b7a1c12de